### PR TITLE
Dockerfile: workaround for node modules not found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,5 +8,10 @@ RUN apt-get-install.sh npm && \
     npm install --production && \
     apt-get-purge.sh npm
 
+# Workaround for sandboxed application losing context - manually install the
+# *dependencies* globally.
+# See https://github.com/praekelt/vumi-sandbox/issues/15
+RUN mv ./node_modules /usr/local/lib/
+
 # Copy in the app Javascript
 COPY go-*.js /app/


### PR DESCRIPTION
Fixes #80, at least for now.
