### PR TITLE
MOMNG-144 Turn on '0' for IVR reg Gravida screen

### DIFF
--- a/go-sms_inbound.js
+++ b/go-sms_inbound.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-train_ussd_public.js
+++ b/go-train_ussd_public.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-train_ussd_registration_recognised.js
+++ b/go-train_ussd_registration_recognised.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-train_ussd_registration_unrecognised.js
+++ b/go-train_ussd_registration_unrecognised.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-train_voice_public.js
+++ b/go-train_voice_public.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-train_voice_registration.js
+++ b/go-train_voice_registration.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-ussd_public.js
+++ b/go-ussd_public.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-ussd_registration.js
+++ b/go-ussd_registration.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-voice_public.js
+++ b/go-voice_public.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/go-voice_registration.js
+++ b/go-voice_registration.js
@@ -771,7 +771,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/src/utils_project.js
+++ b/src/utils_project.js
@@ -217,7 +217,6 @@ go.utils_project = {
         var no_restart_states = [
             // voice registration states
             'state_personnel_auth',
-            'state_gravida',
             // voice change states
             'state_msg_receiver_msisdn',
             'state_main_menu',

--- a/test/train_voice_registration.test.js
+++ b/test/train_voice_registration.test.js
@@ -1686,7 +1686,7 @@ describe("Mama Nigeria App", function() {
                     })
                     .run();
             });
-            it("0 - should navigate to state_msg_language (not restart)", function() {
+            it("0 - should navigate to state_personnel_auth (restart)", function() {
                 return tester
                     .setup.user.addr('07030010001')
                     .inputs(
@@ -1701,18 +1701,13 @@ describe("Mama Nigeria App", function() {
                         , '0'           // state_gravida
                     )
                     .check.interaction({
-                        state: 'state_msg_language',
-                        reply: [
-                            'Language?',
-                            '1. english',
-                            '2. igbo',
-                            '3. pidgin'
-                        ].join('\n')
+                        state: 'state_personnel_auth',
+                        reply: 'Welcome to Hello Mama! Please enter your unique personnel code. For example, 12345'
                     })
                     .check.reply.properties({
                         helper_metadata: {
                             voice: {
-                                speech_url: 'http://localhost:8004/api/v1/eng_NG/state_msg_language_1.mp3',
+                                speech_url: 'http://localhost:8004/api/v1/eng_NG/state_personnel_auth_1.mp3',
                                 wait_for: '#',
                                 barge_in: true
                             }

--- a/test/voice_registration.test.js
+++ b/test/voice_registration.test.js
@@ -1839,7 +1839,7 @@ describe("Mama Nigeria App", function() {
                     })
                     .run();
             });
-            it("0 - should navigate to state_msg_language (not restart)", function() {
+            it("0 - should navigate to state_personnel_auth (restart)", function() {
                 return tester
                     .setup.user.addr('07030010001')
                     .inputs(
@@ -1854,18 +1854,13 @@ describe("Mama Nigeria App", function() {
                         , '0'           // state_gravida
                     )
                     .check.interaction({
-                        state: 'state_msg_language',
-                        reply: [
-                            'Language?',
-                            '1. english',
-                            '2. igbo',
-                            '3. pidgin'
-                        ].join('\n')
+                        state: 'state_personnel_auth',
+                        reply: 'Welcome to Hello Mama! Please enter your unique personnel code. For example, 12345'
                     })
                     .check.reply.properties({
                         helper_metadata: {
                             voice: {
-                                speech_url: 'http://localhost:8004/api/v1/eng_NG/state_msg_language_1.mp3',
+                                speech_url: 'http://localhost:8004/api/v1/eng_NG/state_personnel_auth_1.mp3',
                                 wait_for: '#',
                                 barge_in: true
                             }


### PR DESCRIPTION
Previously the '0' had been switched off on the Gravida screen for IVR registration to allow for a '0' input which doesn't take the user back to the start. Given gravida can never be 0, this no longer applies and the universal action for 0 should be reinstated on IVR registration.
