### PR TITLE
Restrict length of MSISDN characters to 11 for registration

### DIFF
--- a/go-sms_inbound.js
+++ b/go-sms_inbound.js
@@ -99,8 +99,7 @@ go.utils = {
     is_valid_msisdn: function(content) {
         return go.utils.check_valid_number(content)
             && content[0] === '0'
-            && content.length >= 10
-            && content.length <= 13;
+            && content.length == 11;
     },
 
     normalize_msisdn: function(raw, country_code) {

--- a/go-train_ussd.js
+++ b/go-train_ussd.js
@@ -99,8 +99,7 @@ go.utils = {
     is_valid_msisdn: function(content) {
         return go.utils.check_valid_number(content)
             && content[0] === '0'
-            && content.length >= 10
-            && content.length <= 13;
+            && content.length == 11;
     },
 
     normalize_msisdn: function(raw, country_code) {

--- a/go-train_voice.js
+++ b/go-train_voice.js
@@ -99,8 +99,7 @@ go.utils = {
     is_valid_msisdn: function(content) {
         return go.utils.check_valid_number(content)
             && content[0] === '0'
-            && content.length >= 10
-            && content.length <= 13;
+            && content.length == 11;
     },
 
     normalize_msisdn: function(raw, country_code) {

--- a/go-ussd_public.js
+++ b/go-ussd_public.js
@@ -99,8 +99,7 @@ go.utils = {
     is_valid_msisdn: function(content) {
         return go.utils.check_valid_number(content)
             && content[0] === '0'
-            && content.length >= 10
-            && content.length <= 13;
+            && content.length == 11;
     },
 
     normalize_msisdn: function(raw, country_code) {

--- a/go-ussd_registration.js
+++ b/go-ussd_registration.js
@@ -99,8 +99,7 @@ go.utils = {
     is_valid_msisdn: function(content) {
         return go.utils.check_valid_number(content)
             && content[0] === '0'
-            && content.length >= 10
-            && content.length <= 13;
+            && content.length == 11;
     },
 
     normalize_msisdn: function(raw, country_code) {

--- a/go-voice_public.js
+++ b/go-voice_public.js
@@ -99,8 +99,7 @@ go.utils = {
     is_valid_msisdn: function(content) {
         return go.utils.check_valid_number(content)
             && content[0] === '0'
-            && content.length >= 10
-            && content.length <= 13;
+            && content.length == 11;
     },
 
     normalize_msisdn: function(raw, country_code) {

--- a/go-voice_registration.js
+++ b/go-voice_registration.js
@@ -99,8 +99,7 @@ go.utils = {
     is_valid_msisdn: function(content) {
         return go.utils.check_valid_number(content)
             && content[0] === '0'
-            && content.length >= 10
-            && content.length <= 13;
+            && content.length == 11;
     },
 
     normalize_msisdn: function(raw, country_code) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -92,8 +92,7 @@ go.utils = {
     is_valid_msisdn: function(content) {
         return go.utils.check_valid_number(content)
             && content[0] === '0'
-            && content.length >= 10
-            && content.length <= 13;
+            && content.length == 11;
     },
 
     normalize_msisdn: function(raw, country_code) {

--- a/test/ussd_registration.test.js
+++ b/test/ussd_registration.test.js
@@ -1294,7 +1294,8 @@ describe("Mama Nigeria App", function() {
                         '08033048990',
                         '080330ab990',
                         '08033048990123',    // 14 chars in length
-                        '0803304899012'      // 13 chars in length
+                        '0803304899012',     // 13 chars in length
+                        '0803304899',        // 10 chars in length
                     ];
 
                     // function call
@@ -1304,7 +1305,7 @@ describe("Mama Nigeria App", function() {
                     }
 
                     // expected results
-                    assert.equal(resultsArray.length, 9);
+                    assert.equal(resultsArray.length, 10);
                     assert.equal(resultsArray[0], false);
                     assert.equal(resultsArray[1], false);
                     assert.equal(resultsArray[2], false);
@@ -1313,7 +1314,8 @@ describe("Mama Nigeria App", function() {
                     assert.equal(resultsArray[5], true);
                     assert.equal(resultsArray[6], false);
                     assert.equal(resultsArray[7], false);
-                    assert.equal(resultsArray[8], true);
+                    assert.equal(resultsArray[8], false);
+                    assert.equal(resultsArray[9], false);
                 });
             });
 


### PR DESCRIPTION
A percentage of users are not receiving calls because they entered incorrect MSISDNs that were either less or more than 11 characters long.

What a valid MSISDN looks like: 09039756628 (11 characters)

All mobile numbers in Nigeria are 11 characters long