### PR TITLE
Performance metrics - average USSD sessions per registration

### DIFF
--- a/go-ussd_registration.js
+++ b/go-ussd_registration.js
@@ -1363,6 +1363,7 @@ go.app = function() {
     var EndState = vumigo.states.EndState;
     var FreeText = vumigo.states.FreeText;
 
+
     var GoApp = App.extend(function(self) {
         App.call(self, 'state_start');
         var $ = self.$;
@@ -1404,6 +1405,7 @@ go.app = function() {
                 )
             ;
 
+            // Average sessions to register - manual instead of helper because of two end states
             var avg_label = [self.metric_prefix, 'avg.sessions_to_register'].join('.');
             var avg_metadata_label = 'sessions_until_state_metric_' + avg_label;
             var avg_states = ['state_end_voice', 'state_end_sms'];

--- a/src/ussd_registration.js
+++ b/src/ussd_registration.js
@@ -51,6 +51,24 @@ go.app = function() {
                 )
             ;
 
+            // Average sessions to register - manual instead of helper because of two end states
+            var avg_label = [self.metric_prefix, 'avg.sessions_to_register'].join('.');
+            var avg_metadata_label = 'sessions_until_state_metric_' + avg_label;
+            var avg_states = ['state_end_voice', 'state_end_sms'];
+            self.im.on('session:new', function(e) {
+                /* Increment sessions counter */
+                mh._increment_metadata(e.im.user, avg_metadata_label);
+            });
+
+            self.im.on('state:enter', function(e) {
+                /* Reset sessions counter and fire metric */
+                if(avg_states.indexOf(e.state.name) != -1) {
+                    var metadata_value = mh._reset_metadata(
+                        e.state.im.user, avg_metadata_label);
+                    return e.state.im.metrics.fire.avg(avg_label, metadata_value);
+                }
+            });
+
         };
 
     // TEXT CONTENT
@@ -206,14 +224,7 @@ go.app = function() {
                     } else {
                         return 'state_msisdn';
                     }
-                },
-
-                /*events: {
-                    'state:enter': function() {
-                        return self.im.metrics.fire.inc(
-                                ([self.metric_prefix, "registrations_started"].join('.')));
-                    }
-                }*/
+                }
             });
         });
 

--- a/test/ussd_registration.test.js
+++ b/test/ussd_registration.test.js
@@ -145,6 +145,38 @@ describe("Mama Nigeria App", function() {
             });
         });
 
+        describe("test avg.sessions_to_register metric", function() {
+            it("should increment metric according to number of sessions", function() {
+                return tester
+                    .setup.user.addr('08080020002')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'   // state_auth_code - personnel code
+                        , '6' // state_msg_receiver - friend_only
+                        , '09092222222'  // state_msisdn
+                        , {session_event: 'close'}  // timeout
+                        , {session_event: 'new'}  // dial in
+                        , '1'  // state_timed_out - yes (continue)
+                        //, '1'  // state_msg_pregnant - mother
+                        , '1'  // state_last_period_month - Jan 15
+                        , '12' // state_last_period_day - 12
+                        , '3' // state_gravida
+                        , '2'  // state_msg_language - igbo
+                        , '2'   // state_msg_type - text smss
+                    )
+                    .check.interaction({
+                        state: 'state_end_sms',
+                        reply: "Thank you. They will now start receiving text messages three times a week on Monday, Wednesday and Friday."
+                    })
+                    .check(function(api) {
+                        var metrics = api.metrics.stores.test_metric_store;
+                        assert.deepEqual(metrics['test.ussd_registration_test.avg.sessions_to_register'].values, [2]);
+                    })
+                    .check.reply.ends_session()
+                    .run();
+            });
+        });
+
         // TEST START OF SESSION ACTIONS
         describe("Start of session", function() {
             it("should reset user answers", function() {
@@ -222,6 +254,7 @@ describe("Mama Nigeria App", function() {
                         var metrics = api.metrics.stores.test_metric_store;
                         assert.deepEqual(metrics['test.ussd_registration_test.registrations_started'].values, [1]);
                         assert.deepEqual(metrics['test.ussd_registration_test.registrations_completed'], undefined);
+                        assert.deepEqual(metrics['test.ussd_registration_test.avg.sessions_to_register'], undefined);
                     })
                     .run();
             });
@@ -718,6 +751,7 @@ describe("Mama Nigeria App", function() {
                         var metrics = api.metrics.stores.test_metric_store;
                         assert.deepEqual(metrics['test.ussd_registration_test.registrations_started'].values, [1]);
                         assert.deepEqual(metrics['test.ussd_registration_test.registrations_completed'].values, [1]);
+                        assert.deepEqual(metrics['test.ussd_registration_test.avg.sessions_to_register'].values, [1]);
                     })
                     .check.reply.ends_session()
                     .run();
@@ -746,6 +780,7 @@ describe("Mama Nigeria App", function() {
                         var metrics = api.metrics.stores.test_metric_store;
                         assert.deepEqual(metrics['test.ussd_registration_test.registrations_started'].values, [1]);
                         assert.deepEqual(metrics['test.ussd_registration_test.registrations_completed'].values, [1]);
+                        assert.deepEqual(metrics['test.ussd_registration_test.avg.sessions_to_register'].values, [1]);
                     })
                     .check.reply.ends_session()
                     .run();


### PR DESCRIPTION
This creates triggers manually rather than using the metrics helper because we have two end states and the metrics helper does not support this.