### PR TITLE
Remove initial language choice state from training line

### DIFF
--- a/go-train_voice.js
+++ b/go-train_voice.js
@@ -1484,7 +1484,7 @@ go.app = function() {
                             return self.im.user
                                 .set_lang(self.im.config.default_language)
                                 .then(function() {
-                                    return self.states.create('state_set_language');
+                                    return self.states.create('state_msg_receiver_msisdn');
                                 });
                         default: 'state_start';
                     }
@@ -1941,27 +1941,6 @@ go.app = function() {
     // CHANGE
 
     // initial change states
-
-        self.add('state_set_language', function(name) {
-            var speech_option = '1';
-            return new ChoiceState(name, {
-                question: $('Language?'),
-                helper_metadata: go.utils_project.make_voice_helper_data(
-                    self.im, name, self.im.user.lang, speech_option),
-                choices: [
-                    new Choice('eng_NG', $('English')),
-                    new Choice('ibo_NG', $('Igbo')),
-                    new Choice('pcm_NG', $('Pidgin'))
-                ],
-                next: function(choice) {
-                    return self.im.user
-                        .set_lang(choice.value)
-                        .then(function() {
-                            return 'state_msg_receiver_msisdn';
-                        });
-                }
-            });
-        });
 
         // FreeText st-B
         self.add('state_msg_receiver_msisdn', function(name, creator_opts) {

--- a/src/train_voice.js
+++ b/src/train_voice.js
@@ -78,7 +78,7 @@ go.app = function() {
                             return self.im.user
                                 .set_lang(self.im.config.default_language)
                                 .then(function() {
-                                    return self.states.create('state_set_language');
+                                    return self.states.create('state_msg_receiver_msisdn');
                                 });
                         default: 'state_start';
                     }
@@ -535,27 +535,6 @@ go.app = function() {
     // CHANGE
 
     // initial change states
-
-        self.add('state_set_language', function(name) {
-            var speech_option = '1';
-            return new ChoiceState(name, {
-                question: $('Language?'),
-                helper_metadata: go.utils_project.make_voice_helper_data(
-                    self.im, name, self.im.user.lang, speech_option),
-                choices: [
-                    new Choice('eng_NG', $('English')),
-                    new Choice('ibo_NG', $('Igbo')),
-                    new Choice('pcm_NG', $('Pidgin'))
-                ],
-                next: function(choice) {
-                    return self.im.user
-                        .set_lang(choice.value)
-                        .then(function() {
-                            return 'state_msg_receiver_msisdn';
-                        });
-                }
-            });
-        });
 
         // FreeText st-B
         self.add('state_msg_receiver_msisdn', function(name, creator_opts) {

--- a/test/train_voice.test.js
+++ b/test/train_voice.test.js
@@ -2027,7 +2027,7 @@ describe("Mama Nigeria App", function() {
             // TEST START ROUTING
 
             describe("Start of session", function() {
-                it("to state_set_language", function() {
+                it("to state_msg_receiver_msisdn", function() {
                     return tester
                         .setup.user.addr('+2345059991111')
                         .inputs(
@@ -2035,12 +2035,12 @@ describe("Mama Nigeria App", function() {
                             , '2'  // state_training_intro - change
                         )
                         .check.interaction({
-                            state: 'state_set_language'
+                            state: 'state_msg_receiver_msisdn'
                         })
                         .check.reply.properties({
                             helper_metadata: {
                                 voice: {
-                                    speech_url: ['http://localhost:8004/api/v1/eng_NG/state_set_language_1.mp3'],
+                                    speech_url: ['http://localhost:8004/api/v1/eng_NG/state_msg_receiver_msisdn_1.mp3'],
                                     wait_for: '#',
                                     barge_in: true
                                 }
@@ -2064,7 +2064,6 @@ describe("Mama Nigeria App", function() {
                         .inputs(
                             {session_event: 'new'}
                             , '2'  // state_training_intro - change
-                            , '2'  // state_set_language - igbo
                             , '5551234'  // msg_receiver_msisdn
                         )
                         .check.interaction({
@@ -2074,8 +2073,8 @@ describe("Mama Nigeria App", function() {
                             helper_metadata: {
                                 voice: {
                                     speech_url: [
-                                        'http://localhost:8004/api/v1/ibo_NG/state_error_invalid_number.mp3',
-                                        'http://localhost:8004/api/v1/ibo_NG/state_msg_receiver_msisdn_1.mp3'
+                                        'http://localhost:8004/api/v1/eng_NG/state_error_invalid_number.mp3',
+                                        'http://localhost:8004/api/v1/eng_NG/state_msg_receiver_msisdn_1.mp3'
                                     ],
                                     wait_for: '#',
                                     barge_in: true
@@ -2092,7 +2091,6 @@ describe("Mama Nigeria App", function() {
                         .inputs(
                             {session_event: 'new'}
                             , '2'  // state_training_intro - change
-                            , '2'  // state_set_language - igbo
                             , '5551234'  // state_msg_receiver_msisdn
                             , '0'  // state_msg_receiver_msisdn - restart
                         )
@@ -2103,8 +2101,8 @@ describe("Mama Nigeria App", function() {
                             helper_metadata: {
                                 voice: {
                                     speech_url: [
-                                        'http://localhost:8004/api/v1/ibo_NG/state_error_invalid_number.mp3',
-                                        'http://localhost:8004/api/v1/ibo_NG/state_msg_receiver_msisdn_1.mp3'
+                                        'http://localhost:8004/api/v1/eng_NG/state_error_invalid_number.mp3',
+                                        'http://localhost:8004/api/v1/eng_NG/state_msg_receiver_msisdn_1.mp3'
                                     ],
                                     wait_for: '#',
                                     barge_in: true
@@ -2119,7 +2117,6 @@ describe("Mama Nigeria App", function() {
                         .inputs(
                             {session_event: 'new'}
                             , '2'  // state_training_intro - change
-                            , '2'  // state_set_language - igbo
                             , '5551234'  // state_msg_receiver_msisdn
                             , '*'   // state_msg_receiver_msisdn - repeat
                         )
@@ -2130,8 +2127,8 @@ describe("Mama Nigeria App", function() {
                             helper_metadata: {
                                 voice: {
                                     speech_url: [
-                                        'http://localhost:8004/api/v1/ibo_NG/state_error_invalid_number.mp3',
-                                        'http://localhost:8004/api/v1/ibo_NG/state_msg_receiver_msisdn_1.mp3'
+                                        'http://localhost:8004/api/v1/eng_NG/state_error_invalid_number.mp3',
+                                        'http://localhost:8004/api/v1/eng_NG/state_msg_receiver_msisdn_1.mp3'
                                     ],
                                     wait_for: '#',
                                     barge_in: true
@@ -2146,7 +2143,6 @@ describe("Mama Nigeria App", function() {
                         .inputs(
                             {session_event: 'new'}
                             , '2'  // state_training_intro - change
-                            , '2'  // state_set_language - igbo
                             , '05059992222'  // msg_receiver_msisdn
                         )
                         .check.interaction({
@@ -2155,7 +2151,7 @@ describe("Mama Nigeria App", function() {
                         .check.reply.properties({
                             helper_metadata: {
                                 voice: {
-                                    speech_url: ['http://localhost:8004/api/v1/ibo_NG/state_main_menu_1.mp3'],
+                                    speech_url: ['http://localhost:8004/api/v1/eng_NG/state_main_menu_1.mp3'],
                                     wait_for: '#',
                                     barge_in: true
                                 }
@@ -2172,7 +2168,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '3'  // state_set_language - pidgin
                         , '05059992222'  // msg_receiver_msisdn
                         , '1'  // main_menu - baby
                     )
@@ -2182,7 +2177,7 @@ describe("Mama Nigeria App", function() {
                     .check.reply.properties({
                         helper_metadata: {
                             voice: {
-                                speech_url: ['http://localhost:8004/api/v1/pcm_NG/state_baby_confirm_subscription_1.mp3'],
+                                speech_url: ['http://localhost:8004/api/v1/eng_NG/state_baby_confirm_subscription_1.mp3'],
                                 wait_for: '#',
                                 barge_in: true
                             }
@@ -2196,7 +2191,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '3'  // state_set_language - pidgin
                         , '05059992222'  // msg_receiver_msisdn
                         , '1'  // main_menu - baby
                         , '1'  // state_baby_confirm_subscription
@@ -2207,7 +2201,7 @@ describe("Mama Nigeria App", function() {
                     .check.reply.properties({
                         helper_metadata: {
                             voice: {
-                                speech_url: ['http://localhost:8004/api/v1/pcm_NG/state_end_baby_1.mp3'],
+                                speech_url: ['http://localhost:8004/api/v1/eng_NG/state_end_baby_1.mp3'],
                                 wait_for: '#',
                                 barge_in: false
                             }
@@ -2224,7 +2218,6 @@ describe("Mama Nigeria App", function() {
                         .inputs(
                             {session_event: 'new'}
                             , '2'  // state_training_intro - change
-                            , '3'  // state_set_language - pidgin
                             , '05059992222'  // msg_receiver_msisdn
                             , '2'  // main_menu - msg_pref
                         )
@@ -2234,7 +2227,7 @@ describe("Mama Nigeria App", function() {
                         .check.reply.properties({
                             helper_metadata: {
                                 voice: {
-                                    speech_url: ['http://localhost:8004/api/v1/pcm_NG/state_change_menu_sms_1.mp3'],
+                                    speech_url: ['http://localhost:8004/api/v1/eng_NG/state_change_menu_sms_1.mp3'],
                                     wait_for: '#',
                                     barge_in: true
                                 }
@@ -2248,7 +2241,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '3'  // state_set_language - pidgin
                         , '05059992222'  // msg_receiver_msisdn
                         , '2'  // main_menu - msg_pref
                         , '1'  // state_change_menu_sms - change text to voice
@@ -2259,7 +2251,7 @@ describe("Mama Nigeria App", function() {
                     .check.reply.properties({
                         helper_metadata: {
                             voice: {
-                                speech_url: ['http://localhost:8004/api/v1/pcm_NG/state_change_voice_days_1.mp3'],
+                                speech_url: ['http://localhost:8004/api/v1/eng_NG/state_change_voice_days_1.mp3'],
                                 wait_for: '#',
                                 barge_in: true
                             }
@@ -2273,7 +2265,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '3'  // state_set_language - pidgin
                         , '05059992222'  // msg_receiver_msisdn
                         , '2'  // main_menu - msg_pref
                         , '1'  // state_change_menu_sms - change text to voice
@@ -2285,7 +2276,7 @@ describe("Mama Nigeria App", function() {
                     .check.reply.properties({
                         helper_metadata: {
                             voice: {
-                                speech_url: ['http://localhost:8004/api/v1/pcm_NG/state_change_voice_times_1.mp3'],
+                                speech_url: ['http://localhost:8004/api/v1/eng_NG/state_change_voice_times_1.mp3'],
                                 wait_for: '#',
                                 barge_in: true
                             }
@@ -2299,7 +2290,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '3'  // state_set_language - pidgin
                         , '05059992222'  // msg_receiver_msisdn
                         , '2'  // main_menu - msg_pref
                         , '1'  // state_change_menu_sms - change text to voice
@@ -2312,7 +2302,7 @@ describe("Mama Nigeria App", function() {
                     .check.reply.properties({
                         helper_metadata: {
                             voice: {
-                                speech_url: ['http://localhost:8004/api/v1/pcm_NG/state_end_voice_confirm_2.mp3'],
+                                speech_url: ['http://localhost:8004/api/v1/eng_NG/state_end_voice_confirm_2.mp3'],
                                 wait_for: '#',
                                 barge_in: false
                             }
@@ -2329,7 +2319,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222' // state_msg_receiver_msisdn
                         , '3'           // state_main_menu - number
                     )
@@ -2353,7 +2342,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222' // state_msg_receiver_msisdn
                         , '3'           // state_main_menu - number
                         , '54321'       // state_new_msisdn
@@ -2381,7 +2369,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222' // state_msg_receiver_msisdn
                         , '3'           // state_main_menu - number
                         , '05059998888'  // state_new_msisdn
@@ -2409,7 +2396,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222' // state_msg_receiver_msisdn
                         , '4'           // state_main_menu - language
                     )
@@ -2434,7 +2420,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222' // state_msg_receiver_msisdn
                         , '4'           // state_main_menu - language
                         , '3'   // state_change_msg_language - pidgin
@@ -2464,7 +2449,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // state_main_menu - optout
                     )
@@ -2489,7 +2473,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // main_menu - optout
                         , '1'  // optout_reason - miscarriage
@@ -2515,7 +2498,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // main_menu - optout
                         , '1'  // optout_reason - miscarriage
@@ -2543,7 +2525,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // main_menu - optout
                         , '1'  // optout_reason - miscarriage
@@ -2571,7 +2552,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // main_menu - optout
                         , '2'  // optout_reason - stillborn
@@ -2597,7 +2577,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // main_menu - optout
                         , '3'  // optout_reason - baby_died
@@ -2623,7 +2602,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // main_menu - optout
                         , '4'  // optout_reason - not_useful
@@ -2649,7 +2627,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // main_menu - optout
                         , '4'  // optout_reason - not_useful
@@ -2676,7 +2653,6 @@ describe("Mama Nigeria App", function() {
                     .inputs(
                         {session_event: 'new'}
                         , '2'  // state_training_intro - change
-                        , '1'  // state_set_language - english
                         , '05059992222'  // msg_receiver_msisdn
                         , '5'  // main_menu - optout
                         , '1'  // optout_reason - miscarriage


### PR DESCRIPTION
We no longer want the language choice state at the start of the public section of the training line.