### PR TITLE
Fix baby change on public voice line

### DIFF
--- a/go-voice_public.js
+++ b/go-voice_public.js
@@ -1644,7 +1644,7 @@ go.app = function() {
                     } else if (postbirth_sub === 'no_active_subs_found') {
                         return self.states.create('state_baby_switch_broken');  // TODO #101
                     } else {
-                        return self.states.create('state_end_baby');
+                        return self.states.create('state_change_baby');
                     }
                 });
         });

--- a/src/voice_public.js
+++ b/src/voice_public.js
@@ -238,7 +238,7 @@ go.app = function() {
                     } else if (postbirth_sub === 'no_active_subs_found') {
                         return self.states.create('state_baby_switch_broken');  // TODO #101
                     } else {
-                        return self.states.create('state_end_baby');
+                        return self.states.create('state_change_baby');
                     }
                 });
         });

--- a/test/voice_public.test.js
+++ b/test/voice_public.test.js
@@ -351,7 +351,7 @@ describe("Mama Nigeria App", function() {
                     }
                 })
                 .check(function(api) {
-                    go.utils.check_fixtures_used(api, [2,9,16,17,25]);
+                    go.utils.check_fixtures_used(api, [2,9,16,17,25,74]);
                 })
                 .run();
             });
@@ -377,7 +377,7 @@ describe("Mama Nigeria App", function() {
                     }
                 })
                 .check(function(api) {
-                    go.utils.check_fixtures_used(api, [4,5,19,20,25]);
+                    go.utils.check_fixtures_used(api, [4,5,19,20,25,75]);
                 })
                 .run();
             });
@@ -402,7 +402,7 @@ describe("Mama Nigeria App", function() {
                     }
                 })
                 .check(function(api) {
-                    go.utils.check_fixtures_used(api, [7,12,13,22,23,25]);
+                    go.utils.check_fixtures_used(api, [7,12,13,22,23,25,76]);
                 })
                 .run();
             });
@@ -427,7 +427,7 @@ describe("Mama Nigeria App", function() {
                     }
                 })
                 .check(function(api) {
-                    go.utils.check_fixtures_used(api, [6,7,13,22,23,25]);
+                    go.utils.check_fixtures_used(api, [6,7,13,22,23,25,76]);
                 })
                 .run();
             });


### PR DESCRIPTION
The public voice line gives users the option to change to postbirth messages but never actually changes them. Investigation showed that it was skipping the state that actually makes the change