### PR TITLE
Allow subscribed mothers to be family/friend/other

### DIFF
--- a/go-ussd_registration.js
+++ b/go-ussd_registration.js
@@ -1670,9 +1670,11 @@ go.app = function() {
                     return go.utils
                         .get_identity_by_address({'msisdn': msisdn}, self.im)
                         .then(function(contact) {
-                            if (contact === undefined || contact === null) {
+                            if (contact === undefined || contact === null ||
+                                    self.im.user.answers.state_msg_receiver != 'mother_only') {
                                 return 'state_save_identities';
                             }
+
                             return go.utils_project
                                 .check_is_subscribed(
                                     self.im, contact.id, 'prebirth.mother')

--- a/go-voice_registration.js
+++ b/go-voice_registration.js
@@ -1588,7 +1588,8 @@ go.app = function() {
                         return go.utils
                             .get_identity_by_address({'msisdn': msisdn}, self.im)
                             .then(function(contact) {
-                                if (contact === undefined || contact === null) {
+                                if (contact === undefined || contact === null ||
+                                        self.im.user.answers.state_msg_receiver != 'mother_only') {
                                     return 'state_save_identities';
                                 }
 

--- a/src/ussd_registration.js
+++ b/src/ussd_registration.js
@@ -265,9 +265,11 @@ go.app = function() {
                     return go.utils
                         .get_identity_by_address({'msisdn': msisdn}, self.im)
                         .then(function(contact) {
-                            if (contact === undefined || contact === null) {
+                            if (contact === undefined || contact === null ||
+                                    self.im.user.answers.state_msg_receiver != 'mother_only') {
                                 return 'state_save_identities';
                             }
+
                             return go.utils_project
                                 .check_is_subscribed(
                                     self.im, contact.id, 'prebirth.mother')

--- a/src/voice_registration.js
+++ b/src/voice_registration.js
@@ -183,7 +183,8 @@ go.app = function() {
                         return go.utils
                             .get_identity_by_address({'msisdn': msisdn}, self.im)
                             .then(function(contact) {
-                                if (contact === undefined || contact === null) {
+                                if (contact === undefined || contact === null ||
+                                        self.im.user.answers.state_msg_receiver != 'mother_only') {
                                     return 'state_save_identities';
                                 }
 

--- a/test/fixtures_registration.js
+++ b/test/fixtures_registration.js
@@ -3388,6 +3388,7 @@ module.exports = function() {
 
         // 78: get identity 09097777777 by msisdn
         {
+            'repeatable': true,
             'request': {
                 'method': 'GET',
                 'params': {
@@ -4096,6 +4097,42 @@ module.exports = function() {
                     "next": null,
                     "previous": null,
                     "results": []
+                }
+            }
+        },
+
+        // 95: create identity communicate through 09097777777
+        {
+            'request': {
+                'method': 'POST',
+                'headers': {
+                    'Authorization': ['Token test_key'],
+                    'Content-Type': ['application/json']
+                },
+                'url': "http://localhost:8001/api/v1/identities/",
+                'data':  {
+                    "communicate_through": "3f7c8851-5204-43f7-af7f-009097777777",
+                    "operator": "cb245673-aa41-4302-ac47-00000000007",
+                    "details": {
+                        "default_addr_type": null,
+                        "addresses":{}
+                    }
+                },
+            },
+            'response': {
+                "code": 201,
+                "data": {
+                    "url": "http://localhost:8001/api/v1/identities/cb245673-aa41-4302-ac47-1234567890/",
+                    "id": "cb245673-aa41-4302-ac47-1234567890",
+                    "version": 1,
+                    "communicate_through": "3f7c8851-5204-43f7-af7f-009097777777",
+                    "details": {
+                        "default_addr_type": null,
+                        "addresses":{}
+                    },
+                    "operator": "cb245673-aa41-4302-ac47-00000000007",
+                    "created_at": "2015-07-10T06:13:29.693272Z",
+                    "updated_at": "2015-07-10T06:13:29.693298Z"
                 }
             }
         },

--- a/test/ussd_registration.test.js
+++ b/test/ussd_registration.test.js
@@ -300,7 +300,7 @@ describe("Mama Nigeria App", function() {
                         , '12345'  // state_auth_code - personnel code
                         , '2' // state_msg_receiver - mother_only
                         , '09097777777'  // state_msisdn
-                        , '1' // state_end_msisdn - try different number
+                        , '1' // state_msisdn - try different number
                     )
                     .check.interaction({
                         state: 'state_msisdn',
@@ -333,7 +333,7 @@ describe("Mama Nigeria App", function() {
                         , '12345'  // state_auth_code - personnel code
                         , '2' // state_msg_receiver - mother_only
                         , '09097777777'  // state_msisdn
-                        , '2' // state_end_msisdn - choose different receiver
+                        , '2' // state_msg_receiver - choose different receiver
                     )
                     .check.interaction({
                         state: 'state_msg_receiver',
@@ -392,7 +392,7 @@ describe("Mama Nigeria App", function() {
                         , '12345'  // state_auth_code - personnel code
                         , '1' // state_msg_receiver - mother_father
                         , '07070050005'  // state_msisdn_mother
-                        , '1' // msisdn - try different number
+                        , '1' // state_msisdn_mother - try different number
                     )
                     .check.interaction({
                         state: 'state_msisdn_mother',

--- a/test/ussd_registration.test.js
+++ b/test/ussd_registration.test.js
@@ -258,7 +258,7 @@ describe("Mama Nigeria App", function() {
                     })
                     .run();
             });
-            it("to state_msisdn", function() {
+            it("to state_msisdn (from state_msg_receiverd)", function() {
                 return tester
                     .setup.user.addr('08080020002')
                     .inputs(
@@ -272,7 +272,85 @@ describe("Mama Nigeria App", function() {
                     })
                     .run();
             });
-            it("to state_msisdn_mother", function() {
+            it("to state_msisdn_already_registered (from state_msisdn)", function() {
+                return tester
+                    .setup.user.addr('08080020002')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'   // state_auth_code - personnel code
+                        , '2' // state_msg_receiver - mother_only
+                        , '09097777777'  // state_msisdn
+                    )
+                    .check.interaction({
+                        state: 'state_msisdn_already_registered',
+                        reply: [
+                            "Sorry, this number is already registered. They must opt-out before continuing.",
+                            "1. Try a different number",
+                            "2. Choose a different receiver",
+                            "3. Exit"
+                        ].join('\n')
+                    })
+                    .run();
+            });
+            it("to state_msisdn (from state_msisdn_already_registered)", function() {
+                return tester
+                    .setup.user.addr('08080020002')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'  // state_auth_code - personnel code
+                        , '2' // state_msg_receiver - mother_only
+                        , '09097777777'  // state_msisdn
+                        , '1' // state_end_msisdn - try different number
+                    )
+                    .check.interaction({
+                        state: 'state_msisdn',
+                        reply: "Please enter the mobile number of the mother. They must consent to receiving messages."
+                    })
+                    .run();
+            });
+            it("to state_end_msisdn (from state_msisdn_already_registered)", function() {
+                return tester
+                    .setup.user.addr('08080020002')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'  // state_auth_code - personnel code
+                        , '2' // state_msg_receiver - mother_only
+                        , '09097777777'  // state_msisdn
+                        , '3' // state_end_msisdn - exit
+                    )
+                    .check.interaction({
+                        state: 'state_end_msisdn',
+                        reply: "Thank you for using the Hello Mama service."
+                    })
+                    .check.reply.ends_session()
+                    .run();
+            });
+            it("to state_msg_receiver (from state_msisdn_already_registered)", function() {
+                return tester
+                    .setup.user.addr('08080020002')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'  // state_auth_code - personnel code
+                        , '2' // state_msg_receiver - mother_only
+                        , '09097777777'  // state_msisdn
+                        , '2' // state_end_msisdn - choose different receiver
+                    )
+                    .check.interaction({
+                        state: 'state_msg_receiver',
+                        reply: [
+                            "Welcome to Hello Mama. Who will receive the messages on their phone?",
+                            "1. Mother, Father",
+                            "2. Mother",
+                            "3. Father",
+                            "4. Mother, family member",
+                            "5. Mother, friend",
+                            "6. Friend",
+                            "7. Family member"
+                        ].join('\n')
+                    })
+                    .run();
+            });
+            it("to state_msisdn_mother (from state_msg_receiver)", function() {
                 return tester
                     .setup.user.addr('08080020002')
                     .inputs(
@@ -286,22 +364,7 @@ describe("Mama Nigeria App", function() {
                     })
                     .run();
             });
-            it("to state_msisdn_household", function() {
-                return tester
-                    .setup.user.addr('08080020002')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '1'       // state_msg_receiver - mother_father
-                        , '08080030003' // state_msisdn_mother
-                    )
-                    .check.interaction({
-                        state: 'state_msisdn_household',
-                        reply: "Please enter the mobile number of the father. They must consent to receiving messages."
-                    })
-                    .run();
-            });
-            it("to state_msisdn_mother_already_registered", function() {
+            it("to state_msisdn_already_registered (from state_msisdn_mother)", function() {
                 return tester
                     .setup.user.addr('08080020002')
                     .inputs(
@@ -337,81 +400,18 @@ describe("Mama Nigeria App", function() {
                     })
                     .run();
             });
-            it("to state_msisdn_already_registered", function() {
-                return tester
-                    .setup.user.addr('08080020002')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'   // state_auth_code - personnel code
-                        , '2' // state_msg_receiver - mother_only
-                        , '09097777777'  // state_msisdn
-                    )
-                    .check.interaction({
-                        state: 'state_msisdn_already_registered',
-                        reply: [
-                            "Sorry, this number is already registered. They must opt-out before continuing.",
-                            "1. Try a different number",
-                            "2. Choose a different receiver",
-                            "3. Exit"
-                        ].join('\n')
-                    })
-                    .run();
-            });
-            it("to state_end_msisdn", function() {
+            it("to state_msisdn_household", function() {
                 return tester
                     .setup.user.addr('08080020002')
                     .inputs(
                         {session_event: 'new'}  // dial in
                         , '12345'  // state_auth_code - personnel code
-                        , '2' // state_msg_receiver - mother_only
-                        , '09097777777'  // state_msisdn
-                        , '3' // state_end_msisdn - exit
+                        , '1'       // state_msg_receiver - mother_father
+                        , '08080030003' // state_msisdn_mother
                     )
                     .check.interaction({
-                        state: 'state_end_msisdn',
-                        reply: "Thank you for using the Hello Mama service."
-                    })
-                    .check.reply.ends_session()
-                    .run();
-            });
-            it("to state_msisdn (from state_msisdn_already_registered)", function() {
-                return tester
-                    .setup.user.addr('08080020002')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '2' // state_msg_receiver - mother_only
-                        , '09097777777'  // state_msisdn
-                        , '1' // state_end_msisdn - try different number
-                    )
-                    .check.interaction({
-                        state: 'state_msisdn',
-                        reply: "Please enter the mobile number of the mother. They must consent to receiving messages."
-                    })
-                    .run();
-            });
-            it("to state_msg_receiver (from state_msisdn_already_registered)", function() {
-                return tester
-                    .setup.user.addr('08080020002')
-                    .inputs(
-                        {session_event: 'new'}  // dial in
-                        , '12345'  // state_auth_code - personnel code
-                        , '2' // state_msg_receiver - mother_only
-                        , '09097777777'  // state_msisdn
-                        , '2' // state_end_msisdn - choose different receiver
-                    )
-                    .check.interaction({
-                        state: 'state_msg_receiver',
-                        reply: [
-                            "Welcome to Hello Mama. Who will receive the messages on their phone?",
-                            "1. Mother, Father",
-                            "2. Mother",
-                            "3. Father",
-                            "4. Mother, family member",
-                            "5. Mother, friend",
-                            "6. Friend",
-                            "7. Family member"
-                        ].join('\n')
+                        state: 'state_msisdn_household',
+                        reply: "Please enter the mobile number of the father. They must consent to receiving messages."
                     })
                     .run();
             });

--- a/test/ussd_registration.test.js
+++ b/test/ussd_registration.test.js
@@ -258,7 +258,7 @@ describe("Mama Nigeria App", function() {
                     })
                     .run();
             });
-            it("to state_msisdn (from state_msg_receiverd)", function() {
+            it("to state_msisdn (from state_msg_receiver)", function() {
                 return tester
                     .setup.user.addr('08080020002')
                     .inputs(
@@ -269,6 +269,35 @@ describe("Mama Nigeria App", function() {
                     .check.interaction({
                         state: 'state_msisdn',
                         reply: "Please enter the mobile number of the family member. They must consent to receiving messages."
+                    })
+                    .run();
+            });
+            it("to state_last_period_month (from state_msisdn - if receiver isn't mother_only)", function() {
+                return tester
+                    .setup.user.addr('08080020002')
+                    .inputs(
+                        {session_event: 'new'}  // dial in
+                        , '12345'  // state_auth_code - personnel code
+                        , '7'       // state_msg_receiver - family_only
+                        , '09097777777'  // already registered as mother
+                    )
+                    .check.interaction({
+                        state: 'state_last_period_month',
+                        reply: [
+                            "Please select the month the woman started her last period:",
+                            "1. January 2015",
+                            "2. December 2014",
+                            "3. November 2014",
+                            "4. October 2014",
+                            "5. September 2014",
+                            "6. More"
+                        ].join('\n')
+                    })
+                    .check(function(api) {
+                        var fixt78 = api.http.fixtures.fixtures[78];
+                        assert.equal(fixt78.uses, 2);
+                        var fixt95 = api.http.fixtures.fixtures[95];
+                        assert.equal(fixt95.uses, 1);
                     })
                     .run();
             });

--- a/test/voice_registration.test.js
+++ b/test/voice_registration.test.js
@@ -638,13 +638,36 @@ describe("Mama Nigeria App", function() {
                         })
                         .run();
                 });
-                it("to state_msisdn_already_registered", function() {
+                it("to state_last_period_year (because it's family_only)", function() {
                     return tester
                         .setup.user.addr('07030010001')
                         .inputs(
                             {session_event: 'new'}
                             , '12345'        // state_personnel_auth
                             , '7'            // state_msg_receiver - family member
+                            , '09097777777'  // state_msisdn
+                        )
+                        .check.interaction({
+                            state: 'state_last_period_year'
+                        })
+                        .check.reply.properties({
+                            helper_metadata: {
+                                voice: {
+                                    speech_url: ['http://localhost:8004/api/v1/eng_NG/state_last_period_year_1.mp3'],
+                                    wait_for: '#',
+                                    barge_in: true
+                                }
+                            }
+                        })
+                        .run();
+                });
+                it("to state_msisdn_already_registered", function() {
+                    return tester
+                        .setup.user.addr('07030010001')
+                        .inputs(
+                            {session_event: 'new'}
+                            , '12345'        // state_personnel_auth
+                            , '2'            // state_msg_receiver - mother_only
                             , '09097777777'  // state_msisdn
                         )
                         .check.interaction({
@@ -667,7 +690,7 @@ describe("Mama Nigeria App", function() {
                         .inputs(
                             {session_event: 'new'}
                             , '12345'        // state_personnel_auth
-                            , '7'            // state_msg_receiver - family member
+                            , '2'            // state_msg_receiver - mother_only
                             , '09097777777'  // state_msisdn
                             , '1'  // state_msisdn_already_registered - register a diff num
                         )
@@ -677,7 +700,7 @@ describe("Mama Nigeria App", function() {
                         .check.reply.properties({
                             helper_metadata: {
                                 voice: {
-                                    speech_url: ['http://localhost:8004/api/v1/eng_NG/state_msisdn_2.mp3'],
+                                    speech_url: ['http://localhost:8004/api/v1/eng_NG/state_msisdn_1.mp3'],
                                     wait_for: '#',
                                     barge_in: true
                                 }
@@ -691,7 +714,7 @@ describe("Mama Nigeria App", function() {
                         .inputs(
                             {session_event: 'new'}
                             , '12345'        // state_personnel_auth
-                            , '7'            // state_msg_receiver - family member
+                            , '2'            // state_msg_receiver - mother_only
                             , '09097777777'  // state_msisdn
                             , '2'  // state_msisdn_already_registered - choose diff receiver
                         )
@@ -709,13 +732,13 @@ describe("Mama Nigeria App", function() {
                         })
                         .run();
                 });
-                it("to state_msg_receiver (from state_msisdn_already_registered)", function() {
+                it("to state_end_msisdn (from state_msisdn_already_registered)", function() {
                     return tester
                         .setup.user.addr('07030010001')
                         .inputs(
                             {session_event: 'new'}
                             , '12345'        // state_personnel_auth
-                            , '7'            // state_msg_receiver - family member
+                            , '2'            // state_msg_receiver - mother_only
                             , '09097777777'  // state_msisdn
                             , '3'  // state_msisdn_already_registered - exit
                         )


### PR DESCRIPTION
We should still allow subscribed mothers to receive messages for friends or family as well.

I reordered some of the ussd tests so that they were more logically grouped. Therefore this PR is a bit messy. I suggest reviewing the commits separately.